### PR TITLE
BUGFIX: Segmentation fault on CyaSSL_BIO_free() when using CyaSSL_BIO_new_socket()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4012,6 +4012,8 @@ int CyaSSL_set_compression(CYASSL* ssl)
             bio->fd    = sfd;
             bio->prev  = 0;
             bio->next  = 0;
+            bio->mem   = NULL;
+            bio->memLen = 0;
         }
         return bio; 
     }


### PR DESCRIPTION
In CyaSSL_BIO_new_socket() bio->mem is never initialized. This will cause freeing of unallocated memory in CyaSSL_BIO_free:

if (bio->mem)
  XFREE(bio->mem, 0, DYNAMIC_TYPE_OPENSSL);

since bio->mem is not NULL, resulting in a crash.

Related code:
https://github.com/cyassl/cyassl/blob/master/src/ssl.c#L4001-L4017
https://github.com/cyassl/cyassl/blob/master/src/ssl.c#L4112-L4113
