### PR TITLE
fix cipherSuite0 byte in sniffer, so ECC is recognised correctly.

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1198,7 +1198,9 @@ static int ProcessServerHello(const byte* input, int* sslBytes,
     *sslBytes -= b;
    
     /* cipher suite */ 
-    (void)*input++;  /* eat first byte, always 0 */
+    b = *input++;  /* first byte, ECC or not */
+    session->sslServer->options.cipherSuite0 = b;
+    session->sslClient->options.cipherSuite0 = b;
     b = *input++;
     session->sslServer->options.cipherSuite = b;
     session->sslClient->options.cipherSuite = b;


### PR DESCRIPTION
While trying to get cyassl working in our sniffing setup, some sessions were misidentified as using elliptic curve crypto while they were not. This patch fixes that problem.
