### PR TITLE
Increased max AltName buffer size (for cert generation)

### DIFF
--- a/cyassl/ctaocrypt/asn_public.h
+++ b/cyassl/ctaocrypt/asn_public.h
@@ -75,10 +75,10 @@ enum Ctc_Encoding {
 #endif
 
 enum Ctc_Misc {
-    CTC_NAME_SIZE    =   64,
-    CTC_DATE_SIZE    =   32,
-    CTC_MAX_ALT_SIZE = 8192,    /* may be huge */
-    CTC_SERIAL_SIZE  =    8
+    CTC_NAME_SIZE    =    64,
+    CTC_DATE_SIZE    =    32,
+    CTC_MAX_ALT_SIZE = 16384,   /* may be huge */
+    CTC_SERIAL_SIZE  =     8
 };
 
 typedef struct CertName {


### PR DESCRIPTION
We've encountered an SSL server whose certificate's subjectAltName exceeds the size of cyassl's altNames buffer that is used during certificate generation.

Example URL: https://www.infosec.co.uk/Pages/ExhibitorPortal/Login.aspx

The proposed patch increases the AltName buffer size used during certificate generation.
