### PR TITLE
DTLS bug fix: Use same sequence number calculation in tls.c and internal.c

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4238,6 +4238,14 @@ static int DoDtlsHandShakeMsg(CYASSL* ssl, byte* input, word32* inOutIdx,
 
 static INLINE word32 GetSEQIncrement(CYASSL* ssl, int verify)
 {
+#ifdef CYASSL_DTLS
+    if (ssl->options.dtls) {
+        if (verify)
+            return ssl->keys.dtls_state.curSeq; /* explicit from peer */
+        else
+            return ssl->keys.dtls_sequence_number - 1; /* already incremented */
+    }
+#endif
     if (verify)
         return ssl->keys.peer_sequence_number++; 
     else


### PR DESCRIPTION
The DTLS sequence number used when decrypting CCM/GCM was taken from
the internal state, instead of from the actual message record.

If any DTLS messages were dropped, the expectation of the next
sequence number was wrong. This lead to a failed MAC check on the next
message to arrive, and an alert was generated.
