### PR TITLE
Re-added the encrypt_keygen function with NULL keys, required for it.

### DIFF
--- a/ctaocrypt/benchmark/benchmark.c
+++ b/ctaocrypt/benchmark/benchmark.c
@@ -1082,6 +1082,8 @@ void bench_ntruKeyGen(void)
 
     for(i = 0; i < genTimes; i++) {
         ntru_crypto_ntru_encrypt_keygen(drbg, NTRU_EES401EP2, &public_key_len,
+                                    NULL, &private_key_len, NULL);
+        ntru_crypto_ntru_encrypt_keygen(drbg, NTRU_EES401EP2, &public_key_len,
                                      public_key, &private_key_len, private_key);
     }
 


### PR DESCRIPTION
NTRU needs that so that it can generate the key sizes on the first pass through so that it can then generate the key on the second pass. Without it, NTRU fails to generate a key.
