### PR TITLE
automate the cert renewal process

### DIFF
--- a/certs/crl/gencrls.sh
+++ b/certs/crl/gencrls.sh
@@ -5,53 +5,53 @@
 
 
 # caCrl
-openssl ca -gencrl -crldays 365 -out crl.pem -keyfile ~/cyassl/certs/ca-key.pem -cert ~/cyassl/certs/ca-cert.pem
+openssl ca -config ../renewcerts/cyassl.cnf -gencrl -crldays 365 -out crl.pem -keyfile ../ca-key.pem -cert ../ca-cert.pem
 
 # metadata
 openssl crl -in crl.pem -text > tmp
 mv tmp crl.pem
-# install
-cp crl.pem ~/cyassl/certs/crl/crl.pem
+# install (only needed if working outside cyassl)
+#cp crl.pem ~/cyassl/certs/crl/crl.pem
 
 # caCrl server revoked
-openssl ca -revoke ~/cyassl/certs/server-cert.pem -keyfile ~/cyassl/certs/ca-key.pem -cert ~/cyassl/certs/ca-cert.pem
+openssl ca -config ../renewcerts/cyassl.cnf -revoke ../server-cert.pem -keyfile ../ca-key.pem -cert ../ca-cert.pem
 
 # caCrl server revoked generation
-openssl ca -gencrl -crldays 365 -out crl.revoked -keyfile ~/cyassl/certs/ca-key.pem -cert ~/cyassl/certs/ca-cert.pem
+openssl ca -config ../renewcerts/cyassl.cnf -gencrl -crldays 365 -out crl.revoked -keyfile ../ca-key.pem -cert ../ca-cert.pem
 
 # metadata
 openssl crl -in crl.revoked -text > tmp
 mv tmp crl.revoked
-# install
-cp crl.revoked ~/cyassl/certs/crl/crl.revoked
+# install (only needed if working outside cyassl)
+#cp crl.revoked ~/cyassl/certs/crl/crl.revoked
 
 # remove revoked so next time through the normal CA won't have server revoked
 cp blank.index.txt demoCA/index.txt
 
 # cliCrl
-openssl ca -gencrl -crldays 365 -out cliCrl.pem -keyfile ~/cyassl/certs/client-key.pem -cert ~/cyassl/certs/client-cert.pem
+openssl ca -config ../renewcerts/cyassl.cnf -gencrl -crldays 365 -out cliCrl.pem -keyfile ../client-key.pem -cert ../client-cert.pem
 
 # metadata
 openssl crl -in cliCrl.pem -text > tmp
 mv tmp cliCrl.pem
-# install
-cp cliCrl.pem ~/cyassl/certs/crl/cliCrl.pem
+# install (only needed if working outside cyassl)
+#cp cliCrl.pem ~/cyassl/certs/crl/cliCrl.pem
 
 # eccCliCRL
-openssl ca -gencrl -crldays 365 -out eccCliCRL.pem -keyfile ~/cyassl/certs/ecc-client-key.pem -cert ~/cyassl/certs/client-ecc-cert.pem
+openssl ca -config ../renewcerts/cyassl.cnf -gencrl -crldays 365 -out eccCliCRL.pem -keyfile ../ecc-client-key.pem -cert ../client-ecc-cert.pem
 
 # metadata
 openssl crl -in eccCliCRL.pem -text > tmp
 mv tmp eccCliCRL.pem
-# install
-cp eccCliCRL.pem ~/cyassl/certs/crl/eccCliCRL.pem
+# install (only needed if working outside cyassl)
+#cp eccCliCRL.pem ~/cyassl/certs/crl/eccCliCRL.pem
 
 # eccSrvCRL
-openssl ca -gencrl -crldays 365 -out eccSrvCRL.pem -keyfile ~/cyassl/certs/ecc-key.pem -cert ~/cyassl/certs/server-ecc.pem
+openssl ca -config ../renewcerts/cyassl.cnf -gencrl -crldays 365 -out eccSrvCRL.pem -keyfile ../ecc-key.pem -cert ../server-ecc.pem
 
 # metadata
 openssl crl -in eccSrvCRL.pem -text > tmp
 mv tmp eccSrvCRL.pem
-# install
-cp eccSrvCRL.pem ~/cyassl/certs/crl/eccSrvCRL.pem
+# install (only needed if working outside cyassl)
+#cp eccSrvCRL.pem ~/cyassl/certs/crl/eccSrvCRL.pem
 

--- a/certs/renewcerts.sh
+++ b/certs/renewcerts.sh
@@ -1,0 +1,232 @@
+﻿#! /bin/bash
+
+###############################################################################
+######################## FUNCTIONS SECTION ####################################
+###############################################################################
+
+#the function that will be called when we are ready to renew the certs.
+function run_renewcerts(){
+    echo "HAVE_NTRU, good to procede."
+    cd certs/
+    echo ""
+    #move the custom cnf into our working directory
+    cp renewcerts/cyassl.cnf cyassl.cnf
+
+    # To generate these all in sha1 add the flag "-sha1" on appropriate lines
+    # That is all lines beginning with:  "openssl req"
+
+    ############################################################
+    ########## update the self-signed client-cert.pem ##########
+    ############################################################
+    echo "Updating client-cert.pem"
+    echo ""
+    #pipe the following arguments to openssl req...
+    echo -e "US\nMontana\nBozeman\nwolfSSL\nProgramming\nwww.wolfssl.com\ninfo@wolfssl.com\n.\n.\n" | openssl req -new -key client-key.pem -nodes -out client-cert.csr
+
+
+    openssl x509 -req -in client-cert.csr -days 1000 -extfile cyassl.cnf -extensions cyassl_opts -signkey client-key.pem -out client-cert.pem
+    rm client-cert.csr
+
+    openssl x509 -in client-cert.pem -text > tmp.pem
+    mv tmp.pem client-cert.pem
+    ############################################################
+    ########## update the self-signed ca-cert.pem ##############
+    ############################################################
+    echo "Updating ca-cert.pem"
+    echo ""
+    #pipe the following arguments to openssl req...
+    echo -e  "US\nMontana\nBozeman\nSawtooth\nConsulting\nwww.wolfssl.com\ninfo@wolfssl.com\n.\n.\n" | openssl req -new -key ca-key.pem -nodes -out ca-cert.csr
+
+    openssl x509 -req -in ca-cert.csr -days 1000 -extfile cyassl.cnf -extensions cyassl_opts -signkey ca-key.pem -out ca-cert.pem
+    rm ca-cert.csr
+
+    openssl x509 -in ca-cert.pem -text > tmp.pem
+    mv tmp.pem ca-cert.pem
+    ###########################################################
+    ########## update and sign server-cert.ptm ################
+    ###########################################################
+    echo "Updating server-cert.pem"
+    echo ""
+    #pipe the following arguments to openssl req...
+    echo -e "US\nMontana\nBozeman\nwolfSSL\nSupport\nwww.wolfssl.com\ninfo@wolfssl.com\n.\n.\n" | openssl req -new -key server-key.pem -nodes > server-req.pem
+
+    openssl x509 -req -in server-req.pem -extfile cyassl.cnf -extensions cyassl_opts -days 1000 -CA ca-cert.pem -CAkey ca-key.pem -set_serial 01 > server-cert.pem
+
+    rm server-req.pem
+
+    openssl x509 -in ca-cert.pem -text > ca_tmp.pem
+    openssl x509 -in server-cert.pem -text > srv_tmp.pem
+    mv srv_tmp.pem server-cert.pem
+    cat ca_tmp.pem >> server-cert.pem
+    rm ca_tmp.pem
+    ############################################################
+    ########## update and sign the server-ecc-rsa.pem ##########
+    ############################################################
+    echo "Updating server-ecc-rsa.pem"
+    echo ""
+    echo -e "US\nMontana\nBozeman\nElliptic - RSAsig\nECC-RSAsig\nwww.wolfssl.com\ninfo@wolfssl.com\n.\n.\n" | openssl req -new -key ecc-key.pem -nodes > server-ecc-req.pem
+
+    openssl x509 -req -in server-ecc-req.pem -extfile cyassl.cnf -extensions cyassl_opts -days 1000 -CA ca-cert.pem -CAkey ca-key.pem -set_serial 01 > server-ecc-rsa.pem
+
+    rm server-ecc-req.pem
+
+    openssl x509 -in server-ecc-rsa.pem -text > tmp.pem
+    mv tmp.pem server-ecc-rsa.pem
+
+    ############################################################
+    ########## make .der files from .pem files #################
+    ############################################################
+    echo "Generating new ca-cert.der, client-cert.der, server-cert.der..."
+    echo ""
+    openssl x509 -inform PEM -in ca-cert.pem -outform DER -out ca-cert.der
+    openssl x509 -inform PEM -in client-cert.pem -outform DER -out client-cert.der
+    openssl x509 -inform PEM -in server-cert.pem -outform DER -out server-cert.der
+    echo "Changing directory to cyassl root..."
+    echo ""
+    cd ../
+    echo "Execute ./gencertbuf.pl..."
+    echo ""
+    ./gencertbuf.pl
+    ############################################################
+    ########## generate the new crls ###########################
+    ############################################################
+
+    echo "Change directory to cyassl/certs"
+    echo ""
+    cd certs
+    echo "We are back in the certs directory"
+    echo ""
+
+    #set up the file system for updating the crls
+    echo "setting up the file system for generating the crls..."
+    echo ""
+    touch crl/index.txt
+    touch crl/crlnumber
+    echo "01" >> crl/crlnumber
+    touch crl/blank.index.txt
+    mkdir crl/demoCA
+    touch crl/demoCA/index.txt
+
+    echo "Updating the crls..."
+    echo ""
+    cd crl
+    echo "changed directory: cd/crl"
+    echo ""
+    ./gencrls.sh
+    echo "ran ./gencrls.sh"
+    echo ""
+
+    #cleanup the file system now that we're done
+    echo "Performing final steps, cleaning up the file system..."
+    echo ""
+
+    rm ../cyassl.cnf
+    rm blank.index.txt
+    rm index.*
+    rm crlnumber*
+    rm -r demoCA
+    echo "Removed ../cyassl.cnf, blank.index.txt, index.*, crlnumber*, demoCA/"
+    echo ""
+
+}
+
+#function for restoring a previous configure state
+function restore_config(){
+    mv tmp.status config.status
+    mv tmp.options.h cyassl/options.h
+    make clean
+    make -j 8
+}
+
+#function for copy and pasting ntru updates
+function move_ntru(){
+    cp ntru-cert.pem certs/ntru-cert.pem
+    cp ntru-cert.der certs/ntru-cert.der
+    cp ntru-key.raw certs/ntru-key.raw
+}
+
+###############################################################################
+##################### THE EXECUTABLE BODY #####################################
+###############################################################################
+
+#start in root.
+cd ../
+#if HAVE_NTRU already defined
+if grep HAVE_NTRU "cyassl/options.h"; then
+
+    #run the function to renew the certs
+    run_renewcerts
+    # run_renewcerts will end in the cyassl/certs/crl dir, backup to root.
+    cd ../../
+    echo "changed directory to cyassl root directory."
+    echo ""
+
+    ############################################################
+    ########## update ntru if already installed ################
+    ############################################################
+
+    # We cannot assume that user has certgen and keygen enabled
+    ./configure --with-ntru --enable-certgen --enable-keygen
+    make check
+
+    #copy/paste ntru-certs and key to certs/
+    move_ntru
+
+#else if HAVE_NTRU not already defined
+else
+    # Save the users configure state
+    echo "Saving the configure state"
+    echo ""
+    cp config.status tmp.status
+    cp cyassl/options.h tmp.options.h
+
+    echo "Running make clean"
+    echo ""
+    make clean
+
+    echo "Configuring with ntru, enabling certgen and keygen"
+    echo ""
+    ./configure --with-ntru --enable-certgen --enable-keygen
+    make check
+
+    # check options.h a second time, if the user had
+    # ntru installed on their system and in the default
+    # path location, then it will now be defined, if the 
+    # user does not have ntru on their system this will fail
+    # again and we will not update any certs until user installs
+    # ntru in the default location
+
+    # if now defined
+    if grep HAVE_NTRU "cyassl/options.h"; then
+        run_renewcerts
+        #run_renewcerts leaves us in cyassl/certs/crl, backup to root
+        cd ../../
+        echo "changed directory to cyassl root directory."
+        echo ""
+
+        move_ntru
+             
+        echo "ntru-certs, and ntru-key.raw have been updated"
+        echo ""
+
+        # restore previous configure state
+        restore_config
+    else
+
+        # restore previous configure state
+        restore_config
+
+        echo ""
+        echo "ntru is not installed at the default location,"
+        echo "or ntru not installed, none of the certs were updated."
+        echo ""
+        echo "The purpose of this script is to update all certificates, please"
+        echo "install ntru in the default location..."
+        echo ""
+        echo "run the following from your home directory (cd ~)"
+        echo "git clone https://github.com/NTRUOpenSourceProject/NTRUEncrypt"
+        echo "cd NTRUEncrypt and run \"make\" then \"make install\""
+        echo "once complete run this script again to update all the certs."
+    fi #END now defined
+fi #END already defined
+

--- a/certs/renewcerts/cyassl.cnf
+++ b/certs/renewcerts/cyassl.cnf
@@ -1,0 +1,170 @@
+#
+# cyassl configuration file 
+#
+HOME        = .
+RANDFILE    = $ENV::HOME/.rnd
+
+oid_section = new_oids
+
+[ new_oids ]
+# Policies used by the TSA examples.
+tsa_policy1 = 1.2.3.4.1
+tsa_policy2 = 1.2.3.4.5.6
+tsa_policy3 = 1.2.3.4.5.7
+
+####################################################################
+[ ca ]
+default_ca  = CA_default        # The default ca section
+
+####################################################################
+[ CA_default ]
+
+####################################################################
+# CHANGE THIS LINE TO BE YOUR CYASSL_ROOT DIRECTORY                #
+#                                                                  #
+dir             = $HOME./..                                        #
+####################################################################
+
+certs            = $dir/certs                 # Where the issued certs are kept
+crl_dir          = $dir/certs/crl             # Where the issued crl are kept
+database         = $dir/certs/crl/demoCA/index.txt # database index file.
+
+new_certs_dir    = $dir/certs                 # default place for new certs.
+
+certificate      = $dir/certs/ca-cert.pem     # The CA certificate
+serial           = $dir/certs/serial          # The current serial number
+crlnumber        = $dir/certs/crl/crlnumber   # the current crl number
+
+crl              = $dir/certs/crl/crl.pem     # The current CRL
+private_key      = $dir/certs/ca-key.pem      # The private key
+RANDFILE         = $dir/certs/private/.rand   # private random number file
+
+x509_extensions  = usr_cert                   # The extentions to add to the cert
+
+name_opt         = ca_default                 # Subject Name options
+cert_opt         = ca_default                 # Certificate field options
+
+default_days     = 1000                       # how long to certify for
+default_crl_days = 30                         # how long before next CRL
+default_md       = default                    # use public key default MD
+preserve         = no                         # keep passed DN ordering
+policy           = policy_match
+
+# For the CA policy
+[ policy_match ]
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+# For the 'anything' policy
+[ policy_anything ]
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+# default req
+[ req ]
+default_bits            = 2048
+default_keyfile         = privkey.pem
+distinguished_name      = req_distinguished_name
+attributes              = req_attributes
+x509_extensions         = v3_ca  # The extentions to add to the self signed cert
+string_mask             = utf8only
+
+#default req_dist_name
+[ req_distinguished_name ]
+countryName                     = Country Name (2 letter code)
+countryName_default             = US
+countryName_min                 = 2
+countryName_max                 = 2
+
+stateOrProvinceName             = State or Province Name (full name)
+stateOrProvinceName_default     = Montana
+
+localityName                    = Locality Name (eg, city)
+localityName_default            = Bozeman
+
+0.organizationName              = Organization Name (eg, company)
+0.organizationName_default      = Sawtooth
+
+organizationalUnitName          = Organizational Unit Name (eg, section)
+organizationalUnitName_default  = Consulting
+
+commonName                      = Common Name (e.g. server FQDN or YOUR name)
+commonName_default              = www.wolfssl.com
+commonName_max                  = 64
+
+emailAddress                    = Email Address
+emailAddress_default            = info@wolfssl.com
+emailAddress_max                = 64
+
+#default req_attr
+[ req_attributes ]
+challengePassword               = A challenge password
+challengePassword_min           = 4
+challengePassword_max           = 20
+unstructuredName                = An optional company name
+
+# These extensions are added when 'ca' signs a request.
+[ usr_cert ]
+basicConstraints=CA:FALSE
+nsComment            = "cyaSSL Generated Certificate using openSSL command line utility."
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+#cyassl extensions
+[cyassl_opts]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer:always
+basicConstraints=CA:true
+
+# Extensions to add to a certificate request
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# Extensions for a typical CA
+[ v3_ca ]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer:always
+basicConstraints = CA:true
+
+# CRL extensions.
+[ crl_ext ]
+authorityKeyIdentifier=keyid:always
+
+# These extensions should be added when creating a proxy certificate
+[ proxy_cert_ext ]
+basicConstraints=CA:FALSE
+nsComment            = "cyaSSL Generated Certificate using openSSL command line utility"
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
+
+#tsa default
+[ tsa ]
+default_tsa = tsa_config1
+
+# These are used by the TSA reply generation only.
+[ tsa_config1 ]
+dir                     = ./demoCA                              # directory
+serial                  = $dir/tsaserial                        # (mandatory)
+crypto_device           = builtin                               # engine
+signer_cert             = $dir/tsacert.pem                      # certificate
+certs                   = $dir/cacert.pem                       # chain 
+signer_key              = $dir/private/tsakey.pem               # (optional)
+default_policy          = tsa_policy1                           # Policy
+other_policies          = tsa_policy2, tsa_policy3              # (optional)
+digests                 = md5, sha1                             # (mandatory)
+accuracy                = secs:1, millisecs:500, microsecs:100  # (optional)
+clock_precision_digits  = 0                                     # (optional)
+ordering                = yes                                   # timestamps?
+tsa_name                = yes                                   # include?
+ess_cert_id_chain       = no                                    # include chain?


### PR DESCRIPTION
Script assumes user has ntru.
Script does not assume user has keygen and certgen enabled. 
If they do not, no certs will be updated as the purpose of this script is to update ALL certs without exception. Logic follows:

___if (ntru defined) {
______update certs, config with ntru, enable certgen/keygen, make check, generate ntru certs/key
______copy/paste ntru certs/key into certs directory
___}
___else (ntru undefined) {
______run config with ntru, enable certgen/keygen, run make check.

______if (ntru was found and is now defined) {
_________copy/paste ntru certs/key into certs directory
_________update the other certs too
______}
______else (ntru still undefined) {
_________do nothing, alert user of lack of ntru, tell them which one to clone from github.
_________after which, run this script again to update ALL certs at one time.
______} end if
___} end if
