### PR TITLE
tirtos build fix: port.c renamed wc_port.c

### DIFF
--- a/tirtos/packages/ti/net/cyassl/package.bld
+++ b/tirtos/packages/ti/net/cyassl/package.bld
@@ -22,7 +22,7 @@ var cyaSSLObjList = [
         "ctaocrypt/src/md4.c",
         "ctaocrypt/src/md5.c",
         "ctaocrypt/src/memory.c",
-        "ctaocrypt/src/port.c",
+        "ctaocrypt/src/wc_port.c",
         "ctaocrypt/src/pwdbased.c",
         "ctaocrypt/src/random.c",
         "ctaocrypt/src/rsa.c",


### PR DESCRIPTION
current CyaSSL version will not build with TIRTOS.

Change has been tested. 
Result: Clean Build, 0 warnings, 0 errors.
