### PR TITLE
All encryptions work. settings.h generic, allow end user mod

### DIFF
--- a/cyassl/ctaocrypt/settings.h
+++ b/cyassl/ctaocrypt/settings.h
@@ -285,10 +285,6 @@
     #define SIZEOF_LONG_LONG 8
     #define NO_WRITEV
     #define NO_CYASSL_DIR
-    #define NO_SHA512
-    #define NO_DH
-    #define NO_HC128
-    #define NO_RABBIT
     #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
     #define NO_DEV_RANDOM


### PR DESCRIPTION
TI-RTOS settings.h defines modified to be more generic. Allowing end users to more easily modify their projects. Also will allow our example of benchmark to run all tests without having to tell developers to edit their settings.h prior to running the example.
