### PR TITLE
All suites build initially

### DIFF
--- a/tirtos/packages/ti/net/cyassl/package.bld
+++ b/tirtos/packages/ti/net/cyassl/package.bld
@@ -10,7 +10,7 @@ Pkg.makePrologue = "vpath %.c $(subst ;,  ,$(XPKGPATH))";
 
 /* CYASSL sources */
 var cyaSSLObjList = [
-"ctaocrypt/src/aes.c",
+    "ctaocrypt/src/aes.c",
     "ctaocrypt/src/arc4.c",
     "ctaocrypt/src/asm.c",
     "ctaocrypt/src/asn.c",


### PR DESCRIPTION
Right now if a user wants to "#define HAVE_CHACHA" they will get a lot of errors. I propose when we initially build cyassl and tirtos together we build all cipher suites that the user may want to test with so if they decide to turn one on they don't have to go edit the cyassl/tirtos/packages/ti/net/cyassl/package.bld file and rebuild a second time just to use any of our other cipher suites.
