### PR TITLE
Updated picoTCP support, based on newer HTTPS demo

### DIFF
--- a/cyassl/ctaocrypt/settings.h
+++ b/cyassl/ctaocrypt/settings.h
@@ -239,17 +239,20 @@
     #include "pico_defines.h"
     #include "pico_stack.h"
     #include "pico_constants.h"
-    #include "pico_bsd_sockets.h"
     #define CUSTOM_RAND_GENERATE pico_rand
 #endif
 
 #ifdef CYASSL_PICOTCP_DEMO
     #define CYASSL_STM32
-    #define FREERTOS
     #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
-    #define XMALLOC(s, h, type)  pvPortMalloc((s))
-    #define XFREE(p, h, type)    vPortFree((p))
+    #define XMALLOC(s, h, type)  PICO_ZALLOC((s))
+    #define XFREE(p, h, type)    PICO_FREE((p))
+    #define SINGLE_THREADED
+    #define NO_WRITEV
+    #define CYASSL_USER_IO
+    #define NO_DEV_RANDOM
+    #define NO_FILESYSTEM
 #endif
 
 #ifdef FREERTOS_WINSIM


### PR DESCRIPTION
Hello,

we updated the support for PICOTCP and PICOTCP_DEMO, in order to be able to compile our HTTPS public demo, using CyaSSL + picoTCP. 

See https://github.com/tass-belgium/cyassl-picotcp  which is currently broken, until this pull request gets accepted.

Changes:
- FreeRTOS no longer needed
- picotcp-bsd library no longer needed
- some flags added for demo compilation under CYASSL_PICOTCP_DEMO

TIA, 

/picoTCP team
