### PR TITLE
add configure error for sniffer without filesystem

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -322,9 +322,9 @@ AC_ARG_ENABLE([sniffer],
        AS_IF([ test "x$enableval" = "xyes" ],[ AC_CHECK_HEADERS([pcap/pcap.h],[ 
            ENABLED_SNIFFTEST=yes 
    ],[ AC_MSG_WARN([cannot enable sniffer test without having libpcap available.]) ]) ])
-   ],[
-       ENABLED_SNIFFER=no
-   ])
+   ],
+   [ ENABLED_SNIFFER=no ]
+   )
 
 AM_CONDITIONAL([BUILD_SNIFFER],   [ test "x$ENABLED_SNIFFER"   = "xyes" ])
 AM_CONDITIONAL([BUILD_SNIFFTEST], [ test "x$ENABLED_SNIFFTEST" = "xyes" ])
@@ -1152,6 +1152,11 @@ AC_ARG_ENABLE([filesystem],
     [ ENABLED_FILESYSTEM=$enableval ],
     [ ENABLED_FILESYSTEM=yes ]
     )
+
+if test "$ENABLED_FILESYSTEM" = "no" && test "$ENABLED_SNIFFER" = "yes"
+    then
+        AC_MSG_ERROR([cannot enable sniffer without enabling filesystem.])
+fi
 
 if test "$ENABLED_FILESYSTEM" = "no"
 then

--- a/cyassl/test.h
+++ b/cyassl/test.h
@@ -10,6 +10,7 @@
 #include <cyassl/ssl.h>
 #include <cyassl/ctaocrypt/types.h>
 #include <cyassl/ctaocrypt/error-crypt.h>
+#include <cyassl/ctaocrypt/random.h>
 
 #ifdef ATOMIC_USER
     #include <cyassl/ctaocrypt/aes.h>
@@ -17,7 +18,6 @@
     #include <cyassl/ctaocrypt/hmac.h>
 #endif
 #ifdef HAVE_PK_CALLBACKS
-    #include <cyassl/ctaocrypt/random.h>
     #include <cyassl/ctaocrypt/asn.h>
     #ifdef HAVE_ECC
         #include <cyassl/ctaocrypt/ecc.h>
@@ -1779,6 +1779,30 @@ static INLINE char* strsep(char **stringp, const char *delim)
 }
 
 #endif /* __hpux__ */
+
+static INLINE const char* mymktemp(char *tempfn, int len, int num)
+{
+    int x;
+    int ret;
+    static const char alphanum[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                   "abcdefghijklmnopqrstuvwxyz";
+    RNG rng;
+    byte out[32];
+    ret = InitRng(&rng);
+
+    int size = len - 1;
+
+    /* Create unique string for trail of filename */
+    for (x = size; x > size - num; x--) {
+        ret = RNG_GenerateBlock(&rng, out, sizeof(out));
+        if (ret != 0)
+            return "Unexpected RNG result";
+        tempfn[x] = alphanum[(int)(*out) % (sizeof(alphanum) - 1)];
+    }
+    tempfn[len] = '\0';
+
+    return tempfn;
+}
 
 #endif /* CyaSSL_TEST_H */
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10889,16 +10889,17 @@ int CyaSSL_DH_generate_key(CYASSL_DH* dh)
                 CyaSSL_BN_free(dh->pub_key);
    
             dh->pub_key = CyaSSL_BN_new();
-            if (dh->pub_key == NULL)
+            if (dh->pub_key == NULL) {
                 CYASSL_MSG("Bad DH new pub");
-
+            }
             if (dh->priv_key)
                 CyaSSL_BN_free(dh->priv_key);
 
             dh->priv_key = CyaSSL_BN_new();
 
-            if (dh->priv_key == NULL)
+            if (dh->priv_key == NULL) {
                 CYASSL_MSG("Bad DH new priv");
+            }
 
             if (dh->pub_key && dh->priv_key) {
                if (CyaSSL_BN_bin2bn(pub, pubSz, dh->pub_key) == NULL)

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -47,12 +47,7 @@ enum {
     NUMARGS = 3
 };
 
-#ifndef USE_WINDOWS_API
-    static const char outputName[] = "/tmp/output";
-#else
-    static const char outputName[] = "output";
-#endif
-
+static const char *outputName;
 
 int myoptind = 0;
 char* myoptarg = NULL;
@@ -72,6 +67,14 @@ char* myoptarg = NULL;
 
 int testsuite_test(int argc, char** argv)
 {
+#ifndef USE_WINDOWS_API
+    char tempName[] = "/tmp/output-XXXXXX";
+    outputName = mymktemp(tempName, 18, 6);
+#else
+    char tempName[] = "fnXXXXXX";
+    outputName = mymktemp(tempName, 8, 6);
+#endif
+
     func_args server_args;
 
     tcp_ready ready;
@@ -139,7 +142,6 @@ int testsuite_test(int argc, char** argv)
         strcpy(echo_args.argv[0], "echoclient");
         strcpy(echo_args.argv[1], "input");
         strcpy(echo_args.argv[2], outputName);
-        remove(outputName);
 
         /* Share the signal, it has the new port number in it. */
         echo_args.signal = server_args.signal;
@@ -181,6 +183,7 @@ int testsuite_test(int argc, char** argv)
     }
 
     CyaSSL_Cleanup();
+    remove(outputName);
     FreeTcpReady(&ready);
 
 #ifdef CYASSL_TIRTOS


### PR DESCRIPTION
'./configure --enable-sniffer --disable-filesystem' not a configuration option at this time. Added error in configure.ac to account for this.