### PR TITLE
fix CyaSSL_cmp_peer_cert_to_file declaration: remove duplicate CYASSL_API

### DIFF
--- a/cyassl/ssl.h
+++ b/cyassl/ssl.h
@@ -836,7 +836,6 @@ CYASSL_API const unsigned char* CyaSSL_X509_get_der(CYASSL_X509*, int*);
 CYASSL_API const unsigned char* CyaSSL_X509_notBefore(CYASSL_X509*);
 CYASSL_API const unsigned char* CyaSSL_X509_notAfter(CYASSL_X509*);
 CYASSL_API int CyaSSL_X509_version(CYASSL_X509*);
-CYASSL_API 
 
 CYASSL_API int CyaSSL_cmp_peer_cert_to_file(CYASSL*, const char*);
 


### PR DESCRIPTION
When CYASSL_DLL is defined then CYASSL_API msvc is either __declspec(dllexport/dllimport) so it is read by the compiler as this for example when building which causes warnings

__declspec(dllexport) __declspec(dllexport) CyaSSL_cmp_peer_cert_to_file
