### PR TITLE
Deprecate CyaSSL library

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,7 @@
+# Deprecation Notice for CyaSSL 
+
+This repository is no longer maintained. The CyaSSL library has been moved to https://github.com/wolfssl/wolfssl. See the new wolfSSL library, which includes a compatibility layer for CyaSSL/CTaoCrypt.
+
 *** Notes, Please read ***
 
 Note 1)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Deprecation Notice for CyaSSL 
+
+This repository is no longer maintained. The CyaSSL library has been moved to https://github.com/wolfssl/wolfssl. See the new wolfSSL library, which includes a compatibility layer for CyaSSL/CTaoCrypt.
+
 # Notes - Please read 
 
 ## Note 1

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 #
 
-AC_INIT([cyassl],[3.3.2],[https://github.com/cyassl/cyassl/issues],[cyassl],[http://www.wolfssl.com])
+AC_INIT([cyassl (deprecated)],[3.3.2],[https://github.com/cyassl/cyassl/issues],[cyassl],[http://www.wolfssl.com])
 
 AC_CONFIG_AUX_DIR([build-aux])
 

--- a/ctaocrypt/src/misc.c
+++ b/ctaocrypt/src/misc.c
@@ -169,5 +169,27 @@ STATIC INLINE void xorbuf(void* buf, const void* mask, word32 count)
         for (i = 0; i < count; i++) b[i] ^= m[i];
     }
 }
+
+/* This routine fills the first len bytes of the memory area pointed by mem
+   with zeros. It ensures compiler optimizations doesn't skip it  */
+STATIC INLINE void ForceZero(void* mem, word32 len)
+{
+    volatile byte* z = (volatile byte*)mem;
+    while (len--) *z++ = 0;
+}
+
+/* check all length bytes for equality, return 0 on success */
+STATIC INLINE int ConstantCompare(const byte* a, const byte* b, int length)
+{
+    int i;
+    int compareSum = 0;
+
+    for (i = 0; i < length; i++) {
+        compareSum |= a[i] ^ b[i];
+    }
+
+    return compareSum;
+}
+
 #undef STATIC
 

--- a/ctaocrypt/src/random.c
+++ b/ctaocrypt/src/random.c
@@ -793,6 +793,8 @@ int GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
 #elif defined(MBED)
 
+#warning "write a real random seed!!!!, just for testing now"
+
 /* write a real one !!!, just for testing board */
 int GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 {

--- a/ctaocrypt/src/wc_port.c
+++ b/ctaocrypt/src/wc_port.c
@@ -34,6 +34,20 @@
 #endif
 
 
+/* Deprecation Notice - This repository is no longer maintained. 
+ * The CyaSSL library has been moved to https://github.com/wolfssl/wolfssl. 
+ * See the new wolfSSL library, which includes a compatibility layer for 
+ * CyaSSL/CTaoCrypt.*/
+#ifndef NO_WARN_DEPRECATED
+    #ifndef _MSC_VER
+        #warning "The CyaSSL library has been deprecated and replaced by wolfSSL. " \
+            "See https://github.com/wolfSSL/wolfssl"
+    #else
+        #pragma message("Warning: The CyaSSL library has been deprecated and replaced by wolfSSL. " \
+            "See https://github.com/wolfSSL/wolfssl")
+    #endif
+#endif
+
 
 #ifdef SINGLE_THREADED
 

--- a/cyassl/ctaocrypt/misc.h
+++ b/cyassl/ctaocrypt/misc.h
@@ -60,6 +60,12 @@ CYASSL_LOCAL
 void   ByteReverseWords64(word64*, const word64*, word32);
 #endif /* WORD64_AVAILABLE */
 
+CYASSL_LOCAL
+void ForceZero(void*, word32);
+
+CYASSL_LOCAL
+int ConstantCompare(const byte*, const byte*, int);
+
 #endif /* NO_INLINE */
 
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -117,6 +117,7 @@ static void NonBlockingSSL_Connect(CYASSL* ssl)
 
 static void Usage(void)
 {
+    printf("%s\n",      PACKAGE_STRING);
     printf("client "    LIBCYASSL_VERSION_STRING
            " NOTE: All files relative to CyaSSL home dir\n");
     printf("-?          Help, print this usage\n");

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -114,6 +114,7 @@ static void NonBlockingSSL_Accept(SSL* ssl)
 
 static void Usage(void)
 {
+    printf("%s\n",      PACKAGE_STRING);
     printf("server "    LIBCYASSL_VERSION_STRING
            " NOTE: All files relative to CyaSSL home dir\n");
     printf("-?          Help, print this usage\n");


### PR DESCRIPTION
Replaced with wolfSSL (see https://github.com/wolfSSL/wolfssl).